### PR TITLE
fix(prune): Fix options parsing typo for getting ext

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ function storeValue (options) {
 // TODO switch to async
 function pruneSnapshots (options) {
   const tests = options.tests
-  const ext = options.tests || DEFAULT_EXTENSION
+  const ext = options.ext || DEFAULT_EXTENSION
 
   la(is.array(tests), 'missing tests', tests)
   const byFilename = R.groupBy(R.prop('file'), tests)


### PR DESCRIPTION
Hello! First off, I really like the project, so thanks for all your hard work!

I cloned the repo (aside: I was looking into implementing bahmutov/snap-shot-it#26, and it doesn't look that hard to do!) and noticed that `npm test` was failing on `pruning snapshots prunes`. I tracked it down to a little typo in the options parsing of `pruneSnapshots`, which this PR fixes.

