### PR TITLE
feat: implemented #32 to optionally configure a custom snapshot directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ line 2
 
 The newlines will be trimmed automatically when loading the snapshot value.
 
+## Other snapshot directory
+
+Run the code with `SNAPSHOT_DIR=test/_snapshots` to configure the directory of the snapshots.
+
 ## Debugging
 
 Run the code with `DEBUG=snap-shot-core` option to see more log messages.

--- a/src/file-system.js
+++ b/src/file-system.js
@@ -15,7 +15,9 @@ const exportObject = require('./utils').exportObject
 
 const cwd = process.cwd()
 const fromCurrentFolder = path.relative.bind(null, cwd)
-const snapshotsFolder = fromCurrentFolder('__snapshots__')
+const snapshotsFolder = process.env.SNAPSHOT_DIR
+  ? path.resolve(cwd, process.env.SNAPSHOT_DIR)
+  : path.resolve(cwd, '__snapshots__')
 
 function loadSnaps (snapshotPath) {
   const full = require.resolve(snapshotPath)


### PR DESCRIPTION
This will fix #32 to configure a custom snapshot directory. The configured path is relative from the cwd.

Note:
When running `SNAPSHOT_DIR=test/_snapshots npm test`, the test fails only on this one: `can use custom raiser function`.

I'm not sure what this "raiser" is doing what affects the snapshot directory. Please take a look before merging.