### PR TITLE
fix(util): exportText treat text as template string

### DIFF
--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -77,6 +77,26 @@ describe('exportText', () => {
     la(is.fn(exportText))
   })
 
+  it('does escape backtick on the text', () => {
+    const formatted = exportText('name', '`code`')
+    const expected = "exports['name'] = `\n\\`code\\`\n`\n"
+    la(formatted === expected, 'expected\n' + expected + '\ngot\n' + formatted)
+  })
+
+  it('does escape template variable on the text', () => {
+    /* eslint-disable no-template-curly-in-string */
+    const formatted = exportText('name', '`${1}`')
+    const expected = "exports['name'] = `\n\\`\\${1}\\`\n`\n"
+    la(formatted === expected, 'expected\n' + expected + '\ngot\n' + formatted)
+    /* eslint-enable no-template-curly-in-string */
+  })
+
+  it('does not replace \\n with \n on the text', () => {
+    const formatted = exportText('name', 'escaped \\n')
+    const expected = "exports['name'] = `\nescaped \\\\n\n`\n"
+    la(formatted === expected, 'expected\n' + expected + '\ngot\n' + formatted)
+  })
+
   it('does not put value on the first line', () => {
     const formatted = exportText('name', 'foo')
     const expected = "exports['name'] = `\nfoo\n`\n"

--- a/src/utils.js
+++ b/src/utils.js
@@ -69,7 +69,14 @@ function exportText (name, value) {
     throw new Error(message)
   }
   la(is.unemptyString(value), 'expected string value', value)
-  const withNewLines = '\n' + value + '\n'
+  // jsesc replace "\n" with "\\n"
+  // https://github.com/mathiasbynens/jsesc/issues/20
+  const serialized = value.split('\n').map(line => {
+    return jsesc(line, {
+      'quotes': 'backtick'
+    })
+  }).join('\n')
+  const withNewLines = '\n' + serialized + '\n'
   return `exports['${name}'] = \`${withNewLines}\`\n`
 }
 


### PR DESCRIPTION
escape text by jsesc.
`jsesc` support `quote: "backtick"`.


fix #117 