### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ function compare({ expected, value }) {
 Another one, that compares values by type could be even simpler
 
 ```js
-const sameTypes = (a, b) => typeof expected === typeof value
+const sameTypes = (a, b) => typeof a === typeof b
 
 const compareTypes = ({ expected, value }) =>
   sameTypes(expected, value) ? Result.Ok() : Result.Error('types are different')


### PR DESCRIPTION
Could of course also have changed the arguments to be expected and value but I feel like it makes more sense keeping `a` and `b` here as the function doesn't know any of those semantics, and that `compareTypes` is the one that that knows about the semantics of expected and value