### PR TITLE
feat: allow empty string values to be snapshotted

### DIFF
--- a/src/file-system-spec.js
+++ b/src/file-system-spec.js
@@ -78,27 +78,6 @@ describe('file system', () => {
       la(is.fn(saveSnapshots))
     })
 
-    it('throws detailed error when trying to store empty string value', () => {
-      la(
-        is.raises(
-          () => {
-            // snapshots with empty string to save
-            const snapshots = {
-              test: ''
-            }
-            saveSnapshots('./foo-spec.js', snapshots, '.js', {
-              sortSnapshots: true,
-              useRelativePath: false
-            })
-          },
-          err => {
-            const text = 'Cannot store empty / null / undefined string'
-            return err.message.includes(text)
-          }
-        )
-      )
-    })
-
     it('puts new lines around text snapshots', () => {
       sinon.stub(fs, 'writeFileSync')
       sinon.stub(mkdirp, 'sync')
@@ -113,9 +92,9 @@ describe('file system', () => {
       la(
         text === expected,
         'should add newlines around text snapshot\n' +
-          text +
-          '\nexpected\n' +
-          expected
+        text +
+        '\nexpected\n' +
+        expected
       )
     })
   })

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -159,6 +159,12 @@ describe('exportText', () => {
     la(is.fn(exportText))
   })
 
+  it('works properly with empty strings', () => {
+    const formatted = exportText('name', '')
+    const expected = "exports['name'] = `\n\n`\n"
+    la(formatted === expected, 'expected\n' + expected + '\ngot\n' + formatted)
+  })
+
   it('does escape backtick on the text', () => {
     const formatted = exportText('name', '`code`')
     const expected = "exports['name'] = `\n\\`code\\`\n`\n"

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,6 @@ const la = require('lazy-ass')
 const is = require('check-more-types')
 const Result = require('folktale/result')
 const jsesc = require('jsesc')
-const stripIndent = require('common-tags').stripIndent
 
 // TODO: we should also consider the file spec name + test name id:5
 // Gleb Bahmutov
@@ -64,16 +63,7 @@ const compareTypes = options => {
  */
 function exportText (name, value) {
   la(is.unemptyString(name), 'expected snapshot name, got:', name)
-  if (!is.unemptyString(value)) {
-    const message = stripIndent`
-      Cannot store empty / null / undefined string as a snapshot value.
-      Seems the value you are trying to store in a snapshot "${name}"
-      is empty. Snapshots only work well if they have actual content
-      to store. Otherwise, why bother?
-    `
-    throw new Error(message)
-  }
-  la(is.unemptyString(value), 'expected string value', value)
+  la(is.string(value), 'expected string value', value)
 
   // jsesc replace "\n" with "\\n"
   // https://github.com/mathiasbynens/jsesc/issues/20


### PR DESCRIPTION
Previously, `snap-shot-core` would throw an error if you pass an empty string as a value.

With this PR, it will allow it and store the empty string as a snapshot, allowing users to assert that the value of an empty string has not changed.